### PR TITLE
fix(docker): Dockerfileでlogディレクトリの作成を追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ COPY --from=build /rails /rails
 # Run and own only the runtime files as a non-root user for security
 RUN groupadd --system --gid 1000 rails && \
     useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash && \
-    mkdir /data && \
+    mkdir -p /data log && \
     chown -R 1000:1000 db log tmp /data
 USER 1000:1000
 


### PR DESCRIPTION
## 概要
Dockerfileでlogディレクトリが明示的に作成されていなかった問題を修正しました。

## 変更内容
- `/data`ディレクトリと同時に`log`ディレクトリも作成するように修正
- `mkdir /data` → `mkdir -p /data log`

## 影響範囲
- Dockerコンテナのビルドプロセス
- ログファイルの書き込み権限

## テスト
- [ ] Dockerイメージのビルドが成功することを確認
- [ ] コンテナ起動時にlogディレクトリが正しく作成されることを確認
- [ ] railsユーザーがログファイルを書き込めることを確認

## 関連するissue
なし

## コミット
- fix(docker): logディレクトリの作成を追加

🤖 Generated with [Claude Code](https://claude.ai/code)